### PR TITLE
feat: add pdfToolkit.attachExtractedToCopilot command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pdf-toolkit",
-  "version": "1.6.2",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pdf-toolkit",
-      "version": "1.6.2",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "pdfjs-dist": "^5.4.530"
@@ -68,9 +68,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -79,9 +79,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -142,9 +142,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -163,9 +163,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -802,9 +802,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -849,9 +849,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1056,9 +1056,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1090,9 +1090,9 @@
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1263,9 +1263,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -1454,13 +1454,13 @@
       "license": "MIT"
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -1579,9 +1579,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -98,6 +98,11 @@
         "title": "Browse Extracted PDFs",
         "category": "PDF Toolkit",
         "icon": "$(folder-library)"
+      },
+      {
+        "command": "pdfToolkit.attachExtractedToCopilot",
+        "title": "Attach Extracted Pages to Copilot Chat",
+        "category": "PDF Toolkit"
       }
     ],
     "configuration": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -113,6 +113,18 @@ export function activate(context: vscode.ExtensionContext) {
             await browseExtractedPdfs(pdfEditorProvider);
         })
     );
+
+    // Programmatic command to attach extracted PDF images to Copilot Chat
+    context.subscriptions.push(
+        vscode.commands.registerCommand('pdfToolkit.attachExtractedToCopilot', async (args?: {
+            pdf?: string;
+            folder?: string;
+            pages?: string;
+            files?: string[];
+        }) => {
+            await attachExtractedToCopilot(pdfEditorProvider, args);
+        })
+    );
 }
 
 /**
@@ -402,6 +414,174 @@ async function runCustomExtractionWizard(pdfEditorProvider: PdfEditorProvider, t
         resolution.value,
         format.value
     );
+}
+
+/**
+ * Programmatically attach extracted PDF images to Copilot Chat.
+ * 
+ * Accepts args:
+ * - pdf: name of a previously extracted PDF (matches subfolder name)
+ * - folder: explicit absolute path to a folder of images
+ * - pages: page range string like "1,3,5-8" to filter images
+ * - files: explicit list of filenames to attach
+ */
+async function attachExtractedToCopilot(
+    pdfEditorProvider: PdfEditorProvider,
+    args?: {
+        pdf?: string;
+        folder?: string;
+        pages?: string;
+        files?: string[];
+    }
+): Promise<void> {
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+    if (!workspaceFolders) {
+        vscode.window.showErrorMessage('No workspace folder open.');
+        return;
+    }
+
+    // If no args provided, show interactive picker
+    if (!args || (!args.pdf && !args.folder)) {
+        const folderName = PdfEditorProvider.getScreenshotsFolderName();
+        const screenshotsDir = path.join(workspaceFolders[0].uri.fsPath, folderName);
+        const discovered = await scanScreenshotsFolder(screenshotsDir);
+
+        if (discovered.length === 0) {
+            vscode.window.showInformationMessage('No extracted PDFs found. Use the Screenshot button to extract pages from a PDF first.');
+            return;
+        }
+
+        const pdfPick = await vscode.window.showQuickPick(
+            discovered.map(pdf => ({
+                label: pdf.name,
+                description: `${pdf.pageCount} page(s)`,
+                pdf
+            })),
+            { title: '📎 Attach to Copilot Chat', placeHolder: 'Select an extracted PDF' }
+        );
+        if (!pdfPick) { return; }
+
+        // Ask for optional page selection
+        const pageRange = await vscode.window.showInputBox({
+            title: 'Select Pages (optional)',
+            prompt: `Enter page numbers/ranges to attach, or leave empty for all ${pdfPick.pdf.pageCount} page(s)`,
+            placeHolder: 'e.g., 1,3,5-8 or leave empty for all'
+        });
+        if (pageRange === undefined) { return; } // cancelled
+
+        args = {
+            pdf: pdfPick.pdf.name,
+            pages: pageRange || undefined
+        };
+    }
+
+    let targetFolder: string;
+
+    if (args.folder) {
+        targetFolder = args.folder;
+    } else {
+        // Resolve from the screenshots directory using the pdf name
+        const folderName = PdfEditorProvider.getScreenshotsFolderName();
+        targetFolder = path.join(workspaceFolders[0].uri.fsPath, folderName, args.pdf!);
+    }
+
+    // Verify the folder exists
+    try {
+        await vscode.workspace.fs.stat(vscode.Uri.file(targetFolder));
+    } catch {
+        vscode.window.showErrorMessage(`Folder not found: ${targetFolder}`);
+        return;
+    }
+
+    // Read image files from the folder
+    let entries: [string, vscode.FileType][];
+    try {
+        entries = await vscode.workspace.fs.readDirectory(vscode.Uri.file(targetFolder));
+    } catch {
+        vscode.window.showErrorMessage(`Cannot read folder: ${targetFolder}`);
+        return;
+    }
+
+    let imageFiles = entries
+        .filter(([name, type]) => type === vscode.FileType.File && /\.(png|jpe?g)$/i.test(name))
+        .map(([name]) => name)
+        .sort();
+
+    if (imageFiles.length === 0) {
+        vscode.window.showWarningMessage('No image files found in the specified folder.');
+        return;
+    }
+
+    // Filter by explicit file list
+    if (args.files && args.files.length > 0) {
+        const requestedSet = new Set(args.files);
+        imageFiles = imageFiles.filter(f => requestedSet.has(f));
+    }
+
+    // Filter by page range
+    if (args.pages) {
+        const pageNumbers = parsePageRangeForAttach(args.pages);
+        if (pageNumbers.length > 0) {
+            imageFiles = imageFiles.filter(f => {
+                const match = f.match(/page_(\d+)/);
+                if (match) {
+                    return pageNumbers.includes(parseInt(match[1], 10));
+                }
+                return false;
+            });
+        }
+    }
+
+    if (imageFiles.length === 0) {
+        vscode.window.showWarningMessage('No images match the specified selection.');
+        return;
+    }
+
+    if (imageFiles.length > 20) {
+        vscode.window.showWarningMessage(
+            `Selection contains ${imageFiles.length} images, which exceeds Copilot Chat's 20-image limit. Please narrow your selection.`
+        );
+        return;
+    }
+
+    const imageUris = imageFiles.map(f => vscode.Uri.file(path.join(targetFolder, f)));
+
+    await vscode.commands.executeCommand('workbench.action.chat.open', {
+        query: '',
+        attachFiles: imageUris
+    });
+    vscode.window.showInformationMessage(`Attached ${imageFiles.length} image(s) to Copilot Chat.`);
+}
+
+/**
+ * Parse a page range string (e.g. "1,3,5-8") into an array of page numbers.
+ * Used by the programmatic attach command — no maxPage cap needed since
+ * we filter against actual filenames.
+ */
+function parsePageRangeForAttach(rangeStr: string): number[] {
+    const pages: Set<number> = new Set();
+    const parts = rangeStr.split(',');
+
+    for (const part of parts) {
+        const trimmed = part.trim();
+        if (trimmed.includes('-')) {
+            const [startStr, endStr] = trimmed.split('-').map(s => s.trim());
+            const start = parseInt(startStr, 10);
+            const end = parseInt(endStr, 10);
+            if (!isNaN(start) && !isNaN(end) && start >= 1 && end >= start) {
+                for (let i = start; i <= end; i++) {
+                    pages.add(i);
+                }
+            }
+        } else {
+            const page = parseInt(trimmed, 10);
+            if (!isNaN(page) && page >= 1) {
+                pages.add(page);
+            }
+        }
+    }
+
+    return Array.from(pages).sort((a, b) => a - b);
 }
 
 export function deactivate() {}

--- a/src/pdfEditorProvider.ts
+++ b/src/pdfEditorProvider.ts
@@ -360,7 +360,7 @@ export class PdfEditorProvider implements vscode.CustomReadonlyEditorProvider<Pd
     /**
      * Parse page range string like "1,3,5-10" into array of page numbers
      */
-    private parsePageRange(rangeStr: string, maxPage: number): number[] {
+    public parsePageRange(rangeStr: string, maxPage: number): number[] {
         const pages: Set<number> = new Set();
         const parts = rangeStr.split(',');
 


### PR DESCRIPTION
## Summary

Adds a new `pdfToolkit.attachExtractedToCopilot` command that enables programmatic attachment of extracted PDF images to GitHub Copilot Chat.

## What's included

- **New command**: `pdfToolkit.attachExtractedToCopilot`
- **Programmatic API**: Accepts args (`pdf`, `folder`, `pages`, `files`) for automation workflows
- **Interactive fallback**: QuickPick when called from Command Palette with no args
- **20-image guard**: Warns and blocks when selection exceeds Copilot Chat limit
- **Validation**: Checks folder existence, image availability, and selection match
- **Security**: Fixed 5 npm audit vulnerabilities in dev dependencies

## Testing

- Tested locally via Extension Development Host (F5)
- Verified programmatic invocation with args
- Verified interactive fallback from Command Palette
- Verified error cases (no args, missing folder, empty selection, >20 images)

Closes #1